### PR TITLE
アラート関連記事の修正

### DIFF
--- a/articles/AzureBackupGeneral/How_to_set_Backup_Alert.md
+++ b/articles/AzureBackupGeneral/How_to_set_Backup_Alert.md
@@ -55,7 +55,7 @@ Recovery Services コンテナー上でアラートを有効化します。
 
 ![](https://user-images.githubusercontent.com/96324317/205475279-c6bbffff-1b22-482f-9052-478362ba48b4.png)
 
-今回は、Recovery Services コンテナー「RSV-JPE-LRS」にて Azure Files をバックアップ構成しているため、スコープを「Recovery Services コンテナー：RSV-JPE-LRS」としています。
+今回は、Recovery Services コンテナー「RSV-JPE-LRS」にてバックアップ構成しているため、スコープを「Recovery Services コンテナー：RSV-JPE-LRS」としています。
 
 ![](https://user-images.githubusercontent.com/71251920/151009992-071f529c-b069-4e95-b579-57e41d858db5.png)
 

--- a/articles/AzureBackupGeneral/How_to_set_Backup_Alert.md
+++ b/articles/AzureBackupGeneral/How_to_set_Backup_Alert.md
@@ -1,6 +1,6 @@
 ---
 title: 「Azure Monitor を使用した組み込みのアラート」を利用したバックアップ ジョブ失敗のアラート通知作成例
-date: 2022-01-24 12:00:00
+date: 2023-06-30 12:00:00
 tags:
   - Azure Backup General
   - how to
@@ -12,60 +12,94 @@ disableDisclaimer: false
 今回は、**「Azure Monitor を使用した組み込みのアラート」を利用して、Recovery Services コンテナーにてバックアップ構成済のバックアップ ジョブが失敗した際にメール通知を出すよう、アラート処理ルールを作成する例** をご紹介します。
 
 ## 概要
-・「Azure Monitor を使用した組み込みのアラート」を利用
-・アラート処理ルールには、バックアップを構成している対象のRecovery Services コンテナーをスコープとして指定し、バックアップ ジョブが失敗した際に、指定のメールアドレスへ通知メールを送信させる
+- Azure Backup にてこれまで存在していた「クラシック アラート」は、今後廃止される見込みです
+- お客様にて「バックアップ ジョブ失敗のアラートを発生させたい」「発生したアラートをメール通知したい」といった場合
+　今後は「クラシック アラート」ではなく
+　「Azure Monitor を使用した組み込みのアラート」を利用してアラートを構成いただく必要があります
+- 作成概要は公開ドキュメントでも説明しております
+　・ジョブの失敗のシナリオに対して Azure Monitor のアラートを有効にする
+　　https://learn.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor?tabs=recovery-services-vaults#turning-on-azure-monitor-alerts-for-job-failure-scenarios
 
+- アラート処理ルールの作成例として、今回はバックアップを構成している対象のRecovery Services コンテナーをスコープとして指定し、バックアップ ジョブが失敗した際に、指定のメールアドレスへ通知メールを送信させます
 
 ## アラート処理ルール 作成手順
 Azure Backup にて、バックアップ ジョブが失敗した際にアラート通知を出す手段は、下記ドキュメントの通り複数種類ございます。
-今回は **「Azure Monitor を使用した組み込みのアラート」** を利用します。
+今回は「Azure Backup ジョブの失敗を検知したい」という要件である前提で、 **「Azure Monitor を使用した組み込みのアラート」** を利用します。
 ・Azure Backup の監視とレポートのソリューション
 https://docs.microsoft.com/ja-jp/azure/backup/monitoring-and-alerts-overview#monitoring-and-reporting-scenarios
 
-![How_to_set_Backup_Alert_01](https://user-images.githubusercontent.com/96324317/205475179-202669bf-2a8b-48bc-8702-20739561daff.png)
+![](https://github.com/jpabrs-scem/blog/assets/96324317/5ca76af3-d9f4-419f-80f8-3f6812b63764)
 
-「Azure Monitor を使用した組み込みのアラート」を利用した、アラート ルールの作成手順の公開ドキュメントは下記にございます。
+作成手順の公開ドキュメントは下記ですので、基本的に下記ドキュメントの説明に従って設定いただければアラート構成・通知構成が可能です。
 ・ジョブの失敗のシナリオに対して Azure Monitor のアラートを有効にする
-https://docs.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor#turning-on-azure-monitor-alerts-for-job-failure-scenarios
+　https://docs.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor#turning-on-azure-monitor-alerts-for-job-failure-scenarios
 
-・アラートの通知を構成する
-https://docs.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor#configuring-notifications-for-alerts
+### Azure Monitor を使用した組み込みのアラート構成　作業例
+
+Recovery Services コンテナー上でアラートを有効化します。
+![](https://github.com/jpabrs-scem/blog/assets/96324317/e914c143-5391-43da-aea4-ce80006221fd)
+
+有効化することで、バックアップ ジョブが失敗した場合などに、アラートが生成されます。
+
+・Azure portal 内で始動したアラートを確認
+　https://learn.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor?tabs=recovery-services-vaults#viewing-fired-alerts-in-the-azure-portal
+
+![](https://github.com/jpabrs-scem/blog/assets/96324317/42c3d590-7452-456d-ae3e-4cde1a8803e4)
 
 バックアップ センター ＞ アラート処理ルール にて、新しいアラート処理ルールを作成することができます。
 
-![How_to_set_Backup_Alert_02](https://user-images.githubusercontent.com/96324317/205475247-3c6c2195-4eac-4d0e-b1b7-91ca7b8f6f83.png)
+・アラートの通知を構成する
+　https://learn.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor?tabs=recovery-services-vaults#configuring-notifications-for-alerts
 
-![How_to_set_Backup_Alert_03](https://user-images.githubusercontent.com/96324317/205475279-c6bbffff-1b22-482f-9052-478362ba48b4.png)
+![](https://user-images.githubusercontent.com/96324317/205475247-3c6c2195-4eac-4d0e-b1b7-91ca7b8f6f83.png)
+
+![](https://user-images.githubusercontent.com/96324317/205475279-c6bbffff-1b22-482f-9052-478362ba48b4.png)
 
 今回は、Recovery Services コンテナー「RSV-JPE-LRS」にて Azure Files をバックアップ構成しているため、スコープを「Recovery Services コンテナー：RSV-JPE-LRS」としています。
 
-![How_to_set_Backup_Alert_05](https://user-images.githubusercontent.com/71251920/151009992-071f529c-b069-4e95-b579-57e41d858db5.png)
+![](https://user-images.githubusercontent.com/71251920/151009992-071f529c-b069-4e95-b579-57e41d858db5.png)
 
 また、バックアップ ジョブのエラーを検知した際にアラート通知を発報したいため、「フィルター：重要度」とし、「階層：１ - エラー」を選択します。
 ・Azure Backup で保護されたワークロードの監視
 　https://docs.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor#azure-monitor-alerts-for-azure-backup-preview
 
-![How_to_set_Backup_Alert_06](https://user-images.githubusercontent.com/71251920/151009994-805f0f47-4085-4c6b-b1e0-5453f242f62f.png)
+![](https://user-images.githubusercontent.com/71251920/151009994-805f0f47-4085-4c6b-b1e0-5453f242f62f.png)
 
-![How_to_set_Backup_Alert_07](https://user-images.githubusercontent.com/71251920/151009996-9dc217c3-e7ed-43dd-b777-a7f82bf9081b.png)
-
-![How_to_set_Backup_Alert_08](https://user-images.githubusercontent.com/71251920/151009999-50e00252-c95e-47df-b6c9-60fb7255e24a.png)
+![](https://github.com/jpabrs-scem/blog/assets/96324317/afd34bb8-ccd9-458f-bc03-3b1f85fa85ef)
 
 「アクション グループ」には、送信したいメールアドレスを設定しているアクション グループを追加する、もしくは新規作成します。
 今回はあらかじめ作成済のアクション グループを選択しています。
 
+![](https://user-images.githubusercontent.com/71251920/151010003-78799d24-3c6a-4ff6-a8ff-39c7c7c95e90.png)
 
-![How_to_set_Backup_Alert_09](https://user-images.githubusercontent.com/71251920/151010003-78799d24-3c6a-4ff6-a8ff-39c7c7c95e90.png)
+ （補足）アクショングループには、下図のように電子メールへの通知を設定済となっています。
 
- （補足）アクショングループには、下図のように電子メールへの通知を設定済となっています
+![](https://user-images.githubusercontent.com/71251920/151010005-e0d96c25-d7cc-4789-9b1e-6be5458b86f6.png)
 
-![How_to_set_Backup_Alert_10](https://user-images.githubusercontent.com/71251920/151010005-e0d96c25-d7cc-4789-9b1e-6be5458b86f6.png)
+![](https://user-images.githubusercontent.com/71251920/151010009-0b53d0c3-1d15-4902-9059-ad96f54cb6e6.png)
 
-![How_to_set_Backup_Alert_11](https://user-images.githubusercontent.com/71251920/151010009-0b53d0c3-1d15-4902-9059-ad96f54cb6e6.png)
+![](https://user-images.githubusercontent.com/71251920/151010014-e76647b0-3eb5-4cc8-8558-b38636996f48.png)
 
-![How_to_set_Backup_Alert_12](https://user-images.githubusercontent.com/71251920/151010014-e76647b0-3eb5-4cc8-8558-b38636996f48.png)
+アクション グループも有効化されていることを確認しておきます。
+![](https://github.com/jpabrs-scem/blog/assets/96324317/7dfc8bb6-bf41-4135-a194-17a4063c3839)
 
 上図のように設定することで、Recovery Services コンテナー「RSV-JPE-LRS」にてバックアップ構成済のバックアップ ジョブが失敗した際に、指定した電子メール宛先へ、通知メールが送信されるようになります。
 
-![How_to_set_Backup_Alert_13](https://user-images.githubusercontent.com/71251920/151009979-8f6868a8-2edd-4d08-86a5-ef843a877bda.png)
+![](https://user-images.githubusercontent.com/71251920/151009979-8f6868a8-2edd-4d08-86a5-ef843a877bda.png)
 
+ （補足）Azure Backup を意図的に失敗させる手順は下記をご参照ください。
+
+・Azure VM Backup を意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureVMBackup/How_to_fail_VM_backup/
+
+・Azure VM Backup のデータ転送フェーズを意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureVMBackup/How_to_fail_ttv/
+
+・MARS バックアップ を意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/MARSBackup/How_to_fail_MARS_backup/
+
+・Azure Files Backup を意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureFilesBackup/How_to_fail_AFS_backup/
+
+・Azure Disk Backup を意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureDiskBackup/How_to_fail_Asure_Disk_backup/

--- a/articles/MARSBackup/How_to_fail_MARS_backup.md
+++ b/articles/MARSBackup/How_to_fail_MARS_backup.md
@@ -1,6 +1,6 @@
 ---
 title: MARS バックアップ を意図的に失敗させる方法
-date: 2022-02-17 12:00:00
+date: 2023-06-30 12:00:00
 tags:
   - MARS Backup 
   - how to
@@ -9,49 +9,61 @@ disableDisclaimer: false
 
 <!-- more -->
 皆様こんにちは、Azure Backup サポートの 山本 です。
-アラートのテスト等のため "Azure MARS Backup エージェントを利用したバックアップ (以下MARSバックアップ) を失敗させたい" というお問い合わせをよくいただきます。
+アラートのテスト等のため "Azure MARS Backup エージェントを利用したバックアップ (以下 MARS バックアップ) を失敗させたい" というお問い合わせをよくいただきます。
 今回は、**MARS バックアップ を意図的に失敗させる方法**について、ご案内いたします。
 
-なお、下記では Azure VM Backup を失敗させる方法について紹介しております。
-・Azure VM Backup を意図的に失敗させる方法 
-https://jpabrs-scem.github.io/blog/AzureVMBackup/How_to_fail_VM_backup/
-
-
 ### 意図的に MARS バックアップ エラーを発生させる仕組み
-バックアップ対象にフォルダを指定し、ポリシーを設定した後、対象のフォルダ名を変更します。そうすることでバックアップ対象のフォルダがない為にバックアップが失敗します。
+バックアップ対象にフォルダを指定し、バックアップ ポリシーを設定した後、対象のフォルダ名を変更します。
+そうすることでバックアップ対象のフォルダがない為にバックアップ ジョブを失敗させます。
 
 ### MARS バックアップ を失敗させる方法(手順)
-* 以下は MARS エージェントがインストールされているリソース内での作業となります。
+* 以下は MARS エージェントがインストールされているマシン上での作業となります。
 
-#### 1. MARSエージェントのスケジュールバックアップ設定よりテスト用のフォルダをバックアップ対象として選択し、設定します。その他の設定は任意の設定で問題ございません。
-(画像ではデスクトップ上の test フォルダを対象として選択しています)
- ![](https://user-images.githubusercontent.com/71251920/154327014-9a8eb2b3-13e5-48f3-905c-031ae5e7126a.jpg)
+#### 1. MARSエージェントのスケジュール バックアップ設定よりテスト用のフォルダをバックアップ対象として選択し、設定します。
+その他の設定は任意の設定で問題ございません。
+(画像では Test1 フォルダを対象として選択しています)
+![](https://github.com/jpabrs-scem/blog/assets/96324317/7d411329-6157-496b-8e20-f4c4d6d405e7)
 
 #### 2. 上記でバックアップ対象としたフォルダ名を変更します。
-(画像ではtestフォルダをtest_changeフォルダと変更しました)
- ![](https://user-images.githubusercontent.com/71251920/154327016-1281d20b-feb2-4524-8ea5-fa50cecf8359.jpg)
+(画像では Test1 フォルダを Test1<span style="color: red; ">Test1</span> フォルダと変更しました)
+![](https://github.com/jpabrs-scem/blog/assets/96324317/637e0e84-bb2f-4c06-b5a0-fb121e1d51bc)
 
 #### 3. 今すぐバックアップを実行します。
-　バックアップ期間は任意の期間で問題ありません。
- ![](https://user-images.githubusercontent.com/71251920/154327019-106c84e8-9bc7-4df5-9aa3-854e399666ac.jpg)
+バックアップ期間は任意の期間で問題ありません。
+確認画面にて、手順 1 で設定した名前変更前のフォルダが指定されてることを確認し、バックアップを実施してください。
 
-#### 4. 確認画面にて、1で設定した名前変更前のフォルダが指定されてることを確認し、バックアップを実施してください。
- ![](https://user-images.githubusercontent.com/71251920/154327020-f8d375b6-033a-45fb-a5f0-d6c4aafbfe01.jpg)
+![](https://github.com/jpabrs-scem/blog/assets/96324317/541354a9-8367-44d3-8672-7cec4c8a7b6c)
 
-#### 5. バックアップの失敗のメッセージが現れることを確認してください。
-下記画像では Status Details に　Job failed と表示されています。
- ![](https://user-images.githubusercontent.com/71251920/154327021-05c22aec-45ec-4adf-b615-04dc7424662d.jpg)
+#### 4. バックアップの失敗のメッセージが現れることを確認してください。
+![](https://github.com/jpabrs-scem/blog/assets/96324317/9c74ce5b-b778-4976-a07c-0c917e10f939)
 
-###　アラート例
-下記のような Azure Backup の組み込みアラートを設定している場合アラートがメールで通知されます。
-![組み込みアラート](https://user-images.githubusercontent.com/71251920/154327023-c5e4526e-9e9f-4c25-b2b3-faa4bb6f9705.jpg)
+![](https://github.com/jpabrs-scem/blog/assets/96324317/1b09c4c6-3a9d-460f-abfd-f330215e834d)
 
-![アラート通知メール](https://user-images.githubusercontent.com/71251920/154327010-0a5c3e60-a3f3-4919-860d-98a8ae1530d3.jpg)
+![](https://github.com/jpabrs-scem/blog/assets/96324317/c079b915-e93d-46a9-8e55-3d49773e76cf)
 
-><原文>Description: Backup failed as none of the items specified as part of the backup policy exist.
->><抄訳>説明：バックアップポリシーの一部として指定された項目が存在しないため、バックアップが失敗しました。
+###　Azure Monitor を使用した組み込みのアラート メール通知例
+MARS バックアップを構成している Recovery Services コンテナーをスコープに含めた Azure Monitor を使用した組み込みのアラートを構成している場合、下図のようなメール通知が発報されます。
 
+・ジョブの失敗のシナリオに対して Azure Monitor のアラートを有効にする
+　https://learn.microsoft.com/ja-jp/azure/backup/backup-azure-monitoring-built-in-monitor?tabs=recovery-services-vaults#turning-on-azure-monitor-alerts-for-job-failure-scenarios
+
+![](https://github.com/jpabrs-scem/blog/assets/96324317/b2200f28-5b70-42ce-9dd8-12072a03261f)
+
+![](https://github.com/jpabrs-scem/blog/assets/96324317/69860bc1-ec96-4e26-b2e2-72a000b81e8b)
 
 以上で MARS バックアップ を意図的に失敗させる方法に関しましてのご説明は終了となります。
-
 ぜひお試しいただければと思います。
+
+ （補足）その他の Azure Backup を意図的に失敗させる手順は下記にてご紹介しております。
+
+・Azure VM Backup を意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureVMBackup/How_to_fail_VM_backup/
+
+・Azure VM Backup のデータ転送フェーズを意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureVMBackup/How_to_fail_ttv/
+
+・Azure Files Backup を意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureFilesBackup/How_to_fail_AFS_backup/
+
+・Azure Disk Backup を意図的に失敗させる方法 | Japan CSS ABRS Support Blog !! (jpabrs-scem.github.io)
+　https://jpabrs-scem.github.io/blog/AzureDiskBackup/How_to_fail_Asure_Disk_backup/


### PR DESCRIPTION
①　「Azure Monitor を使用した組み込みのアラート」を利用したバックアップ ジョブ失敗のアラート通知作成例 →　公開ドキュメントに従った説明へと修正

②　「MARS バックアップ を意図的に失敗させる方法」
→　画面スクリーンショットの画質が悪かったので刷新
　　クラシック アラート メール通知例になっていたので「Azure Monitor を使用した組み込みのアラート」メール通知例へと変更