### PR TITLE
SAP HANA の障害時ログ収集対象について

### DIFF
--- a/articles/AzureBackupGeneral/RequestForInvestigating.md
+++ b/articles/AzureBackupGeneral/RequestForInvestigating.md
@@ -1,6 +1,6 @@
 ---
 title:  Azure Backup の障害調査に必要な情報
-date: 2022-02-11 12:00:00
+date: 2023-09-27 12:00:00
 tags:
   - Azure Backup General
   - 情報採取
@@ -125,16 +125,18 @@ zip などにまとめてご提供いただけますと幸いです。
 
 ### SAP HANAのbackup.log 及び backint.log 
 >* xxにはインスタンスナンバーが入ります。
-	・/hana/shared/HXE/HDBxx/<hostname>/trace/backup.log
-	・/hana/shared/HXE/HDBxx/<hostname>/trace/DB_<DB名>/backup.log
-	・/hana/shared/HXE/HDBxx/<hostname>/trace/backint.log
-	・/hana/shared/HXE/HDBxx/<hostname>/trace/DB_<DB名>/backint.log
+	・/hana/shared/HXE/HDBxx/(hostname)/trace/backup.log
+	・/hana/shared/HXE/HDBxx/(hostname)/trace/DB_<DB名>/backup.log
+	・/hana/shared/HXE/HDBxx/(hostname)/trace/backint.log
+	・/hana/shared/HXE/HDBxx/(hostname)/trace/DB_<DB名>/backint.log
  
 *上記パスに該当のログが無い場合は以下を試し、コマンド実行結果に表示されるディレクトリの場所の log をアップロードしてください。
->	sudo -i (rootユーザーに切り替えます)
-	cd / (ディレクトリの最上層に移動します)
-	find ./ -name "backup.log" (findコマンドにより該当のログの場所を特定します)
-	find ./ -name "backint.log" (findコマンドにより該当のログの場所を特定します)
+``` shell
+sudo -i (rootユーザーに切り替えます)
+cd / (ディレクトリの最上層に移動します)
+find ./ -name "backup.log" (findコマンドにより該当のログの場所を特定します)
+find ./ -name "backint.log" (findコマンドにより該当のログの場所を特定します)
+```
 
 ### opt 配下の log 
 ・/opt/msawb/var/log ディレクトリ配下のファイルを zip 等におまとめのうえで、アップロードしてください。


### PR DESCRIPTION
#20
@kaiozeki さん ↓
念のためダブルチェックをお願いします！
※ Markdown で
![image](https://github.com/jpabrs-scem/blog/assets/96324317/eb5caff5-6660-4aaa-a5cf-dd4f09b9851d)
のように記載していると、実際のブログ画面上では消えていたので、ここだけ　カッコ () 書きにすることにしました。

@yomiyamoto38 さん ↓
_あと、私の環境だと「DB_HXE_RESTORE」ディレクトリ配下にも backup.log と backint.log がありました。
これは回収する必要は無いですか？_

上記のご指摘ですが、私の環境にはございませんでした。。宮本さんのほうで昔復元とかされて、「DB_HXE_RESTORED」というデータベースが存在していないですかね？
ひとまず、上記指摘部分は追記せずに、修正をしたいと思っております！
![image](https://github.com/jpabrs-scem/blog/assets/96324317/9a762d6c-3f0e-4ccd-95e0-c5248f00df52)